### PR TITLE
fix: fix cannot work at non default AWS Region

### DIFF
--- a/cmd/helmecr/main.go
+++ b/cmd/helmecr/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
@@ -34,7 +35,7 @@ func main() {
 		log.Fatalf("failed to create AWS session: %v", err)
 	}
 
-	ecrService := ecr.New(session)
+	ecrService := ecr.New(session, aws.NewConfig().WithRegion(*repository.Region))
 
 	// Either Helm is asking to add ECR as the Helm repository or Helm index (index.yaml)
 	// either way return newly generated index by describing images matching Helm artifacts


### PR DESCRIPTION
Hi:

I got a issue when running "helm repo add ecr://xxxxxxxxxx". It cannot find the repo.

It's because my ECR repo is in ap-northeast-1, not the default region.

It must assign region to AWS-SDK.

And I fix it.

Thank you